### PR TITLE
feat(task-7): added basic authorizer

### DIFF
--- a/cdk-app.ts
+++ b/cdk-app.ts
@@ -2,13 +2,12 @@
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { ProductService } from './src/product-service/product-service-stack';
-import {Cors, Deployment, Method, RestApi} from "aws-cdk-lib/aws-apigateway";
-import { NestedStack, Stack, StackProps, Stage } from "aws-cdk-lib";
-import { Construct } from "constructs";
-import  { ImportService } from "./src/import-service/import-service-stack";
-import * as sqs from "aws-cdk-lib/aws-sqs";
-import * as sns from "aws-cdk-lib/aws-sns";
-import { EmailSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+import { Cors, Deployment, Method, RestApi } from 'aws-cdk-lib/aws-apigateway';
+import { NestedStack, Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import  { ImportService } from './src/import-service/import-service-stack';
+import { AuthorizationService } from './src/authorization-service/authorization-service-stack';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
 
 class DeployStack extends NestedStack {
     constructor(scope: Construct, props: { restApiId: string; methods: Method[] } & StackProps) {
@@ -38,6 +37,7 @@ class RootStack extends Stack {
             defaultCorsPreflightOptions: {
                 allowOrigins: Cors.ALL_ORIGINS,
                 allowMethods: Cors.ALL_METHODS,
+                allowHeaders: Cors.DEFAULT_HEADERS,
             },
             deploy: true,
             deployOptions: {
@@ -45,9 +45,21 @@ class RootStack extends Stack {
             },
         });
 
+        api.addGatewayResponse("GatewayResponse4XX", {
+            type: cdk.aws_apigateway.ResponseType.DEFAULT_4XX,
+            responseHeaders: {
+                "Access-Control-Allow-Origin": "'*'",
+                "Access-Control-Allow-Headers":
+                    "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+                "Access-Control-Allow-Methods": "'OPTIONS,GET,PUT'",
+            },
+        });
+
         const catalogItemsQueue = new sqs.Queue(this, 'catalog-items-queue', {
             queueName: 'catalogItemsQueue',
         });
+
+        const authorizationService = new AuthorizationService(this);
 
         const productsService = new ProductService(this, {
             restApiId: api.restApiId,
@@ -59,6 +71,7 @@ class RootStack extends Stack {
             restApiId: api.restApiId,
             restApiRootResourceId: api.restApiRootResourceId,
             queArn: catalogItemsQueue.queueArn,
+            tokenAuthorizer: authorizationService.tokenAuthorizer,
         });
 
         new DeployStack(this, {

--- a/src/authorization-service/authorization-service-stack.ts
+++ b/src/authorization-service/authorization-service-stack.ts
@@ -1,0 +1,41 @@
+import { NestedStack } from 'aws-cdk-lib';
+import {Construct} from 'constructs';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { TokenAuthorizer, IdentitySource } from 'aws-cdk-lib/aws-apigateway';
+import { PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Duration } from "aws-cdk-lib";
+
+export class AuthorizationService extends NestedStack {
+    public tokenAuthorizer: TokenAuthorizer;
+
+    constructor(scope: Construct) {
+        super(scope, 'authorization-service');
+
+        const basicAuthorizer = new NodejsFunction(this, 'basic-authorizer', {
+            entry: 'src/authorization-service/lambdas/basicAuthorizer.ts',
+            handler: 'handler',
+            environment: {
+                USER_NAME: process.env.USER_NAME!,
+                USER_PASS: process.env.USER_PASS!
+            }
+        });
+
+        const basicAuthorizerRole = new Role(this, "basic-authorizer-role", {
+            assumedBy: new ServicePrincipal("apigateway.amazonaws.com"),
+        });
+
+        basicAuthorizerRole.addToPolicy(
+            new PolicyStatement({
+                actions: ["lambda:InvokeFunction"],
+                resources: [basicAuthorizer.functionArn],
+            }),
+        );
+
+        this.tokenAuthorizer = new TokenAuthorizer(this, "token-authorizer", {
+            handler: basicAuthorizer,
+            identitySource: IdentitySource.header("authorization"),
+            resultsCacheTtl: Duration.seconds(0),
+            assumeRole: basicAuthorizerRole,
+        });
+    }
+}

--- a/src/authorization-service/lambdas/basicAuthorizer.ts
+++ b/src/authorization-service/lambdas/basicAuthorizer.ts
@@ -1,0 +1,43 @@
+import {
+    APIGatewayAuthorizerResult,
+    APIGatewayTokenAuthorizerEvent,
+} from 'aws-lambda';
+
+export const handler = async (event: APIGatewayTokenAuthorizerEvent):Promise<APIGatewayAuthorizerResult | string> => {
+    console.log(`BASIC_AUTHORIZER: processing`);
+
+    const policyResponse = (access: boolean = false, principalId: string = '') => ({
+        principalId,
+        policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Action: 'execute-api:Invoke',
+                    Effect: access ? 'Allow' : 'Deny',
+                    Resource: event.methodArn,
+                },
+            ],
+        }
+    });
+
+    const token = event.authorizationToken.replace(/^Basic /, '');
+    console.log(`BASIC_AUTHORIZER: token - ${token}`);
+
+    if (!token || token === 'null') {
+        console.log(`BASIC_AUTHORIZER: authorisation token is not provided`);
+        throw new Error('Unauthorized');
+    }
+
+    const buffer = Buffer.from(token, 'base64');
+    const [userName, pass] = buffer.toString('utf-8').split(':');
+
+    const areCredentialsValid = process.env.USER_NAME === userName &&
+        process.env.USER_PASS === pass;
+
+    const response = policyResponse(areCredentialsValid, userName);
+
+    console.log(`BASIC_AUTHORIZER: policy response - ${JSON.stringify(response)}`);
+
+    return response;
+};
+


### PR DESCRIPTION
- [x] **+70** **7.1, 7.2, 7.3, 7.4,** authorization-service added, basicAuthorizer added to /import resource

- [x]  **+30** Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the

Store API - https://7dtijjqfhk.execute-api.us-east-1.amazonaws.com/dev

Frontend app - https://d10z87iyg30ka7.cloudfront.net

Commit  to Frontend app with notifications, and authorisation errors handling - https://github.com/bazloo/nodejs-aws-shop-react/pull/4/commits/1ef03a63860eddadddcdc42f87e0d6dc8b29c8d2

To set **authorization_token**, enter in browser dev console
``localStorage.setItem('authorization_token', 'YmF6bG9vOlRFU1RfUEFTU1dPUkQ=')``
 in this base64 token decoded credentials 'bazloo:TEST_PASSWORD'

example of csv file with mocked products - [download](https://github.com/bazloo/shop-backend-aws/blob/AWS_6_async_microservices_communication/mocked-data/test-usual-comma-separatorl.csv)

## **Self estimation - 100 points**